### PR TITLE
resolved issue 4 by adding Python dependencies

### DIFF
--- a/nubis/puppet/python-deps.pp
+++ b/nubis/puppet/python-deps.pp
@@ -15,8 +15,9 @@ $packages = [
 ]
 
 package {
-  $packages: ensure => 'installed',
-  require           => Exec['apt-get-update'],
+  $packages:
+    ensure  => 'installed',
+    require => Exec['apt-get-update'],
 }
 
 # Pip dependencies

--- a/nubis/puppet/python-deps.pp
+++ b/nubis/puppet/python-deps.pp
@@ -1,0 +1,31 @@
+# Package requirements to help resolve issue-4 in GitHub
+
+# Ensure everything is updated
+exec { 'apt-get-update':
+  command     => '/usr/bin/apt-get update',
+  refreshonly => true,
+}
+
+# Apt dependencies
+$packages = [
+  'python-pip',
+  'build-essential',
+  'libffi-dev',
+  'python-dev'
+]
+
+package {
+  $packages: ensure => 'installed',
+  require           => Exec['apt-get-update'],
+}
+
+# Pip dependencies
+exec { 'pip-idna':
+  command => '/usr/bin/pip install idna',
+  require => Exec['apt-get-update'],
+}
+
+exec { 'pip-pyopenssl':
+  command => '/usr/bin/pip install pyopenssl',
+  require => Exec['apt-get-update'],
+}


### PR DESCRIPTION
This adds the following packages to our AMI:

```
python-pip
build-essential
libffi-dev
python-dev
```

It also installs the python packages `idna` and `pyopenssl`. If this is not sufficient (we'll see after the automated build), we may also have to install `libssl-dev`.

This should resolve: https://github.com/mozilla-it/nubis-planet-mozilla-org/issues/4